### PR TITLE
No GitHub API authentication Error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,7 @@ baseurl: /mm-github-pages-starter
 url: https://mmistakes.github.io
 twitter_username: username
 github_username: username
+github         : # username E.g. mmistakes
 minimal_mistakes_skin: default
 search: true
 


### PR DESCRIPTION
 ## Only [github: ]works, not [github_username:]

>Remote Theme: Using theme mmistakes/minimal-mistakes 
>       Jekyll Feed: Generating feed for posts
>GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
>                    done in 90.87 seconds.
>Auto-regeneration: enabled for 'D:/niklasjang.github.io'
>  Server address: http://127.0.0.1:4000/
>  Server running... press ctrl-c to stop.

So I added 

>>github         : # username E.g. mmistakes
