### PR TITLE
fix: config for windows machine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
+gem "webrick" if Gem.win_platform?
 
 gem "tzinfo-data"
 gem "wdm", "~> 0.1.0" if Gem.win_platform?

--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ Contains basic configuration to get you a site with:
 
 Replace sample content with your own and [configure as necessary](https://mmistakes.github.io/minimal-mistakes/docs/configuration/).
 
+
+## Setup Instruction
+
+1. Clone the repo or download the source code to your local box. 
+2. Install dependencies run `bundle install`
+3. Go to `_config.yml` & Change the repository name to your GitHub repo name  `repository: "githubUser/RepoName"` 
+4. Serve your project `bundle exec jekyll serve`
+5. Visit your site http://127.0.0.1:4000 
+
+
 ---
+
+
 
 ## Troubleshooting
 
@@ -25,3 +37,5 @@ If you have a question about using Jekyll, start a discussion on the [Jekyll For
 - [Ruby 101](https://jekyllrb.com/docs/ruby-101/)
 - [Setting up a Jekyll site with GitHub Pages](https://jekyllrb.com/docs/github-pages/)
 - [Configuring GitHub Metadata](https://github.com/jekyll/github-metadata/blob/master/docs/configuration.md#configuration) to work properly when developing locally and avoid `No GitHub API authentication could be found. Some fields may be missing or have incorrect data.` warnings.
+
+

--- a/_config.yml
+++ b/_config.yml
@@ -23,6 +23,8 @@ twitter_username: username
 github_username: username
 minimal_mistakes_skin: default
 search: true
+# Change the repository name
+repository: "mmistakes/minimal-mistakes" 
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
In Windows machine we get below error therefore I added `webrick`
![image](https://user-images.githubusercontent.com/330383/109316203-5e819c00-7819-11eb-913f-6e4be86b26ca.png)

Also first time run is getting error about repo name so I added dummy repo name and user must change the repo name as per their repo name. 

![image](https://user-images.githubusercontent.com/330383/109316280-72c59900-7819-11eb-8b80-d0d3c89d3bcb.png)

I think u should merge my pull request which will make our template more ready to use.  I also added steps to start jekyll site in our readme file. 