### PR TITLE
Remove deprecated dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,4 @@ group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jemoji"
   gem "jekyll-include-cache"
-  gem "jekyll-algolia"
 end


### PR DESCRIPTION
Support for this gem(jekyll-algolia) was dropped according to https://github.com/algolia/jekyll-algolia. I suggest removing it from the docs; I can handle it if you're short on time.
![image](https://github.com/user-attachments/assets/270d3345-c597-4288-a9af-a42e062ac587)
